### PR TITLE
Fix 10.1 lua error (I think this also prevents saving settings)

### DIFF
--- a/options.lua
+++ b/options.lua
@@ -229,7 +229,7 @@ function GSA:OnOptionCreate()
 	options_created = true -- ***** @
 	self.options = {
 		type = "group",
-		name = GetAddOnMetadata("GladiatorlosSA", "Title"),
+		name = GetAddOnMetadata("GladiatorlosSA2", "Title"),
 		args = {
 			general = {
 				type = 'group',


### PR DESCRIPTION
Lua error:
![image](https://user-images.githubusercontent.com/4195563/236648105-3fb3ee52-639c-4fbe-9725-d0a01f9333cb.png)

Fix:
Change line 232 of options.lua
FROM: 		name = GetAddOnMetadata("GladiatorlosSA", "Title"),
TO: 		        name = GetAddOnMetadata("GladiatorlosSA2", "Title"),
